### PR TITLE
fix: GitHub Actions에서 JAR 파일 경로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Generate deployment package
       run: |
         mkdir -p deploy
-        cp build/libs/*.jar deploy/application.jar
+        cp build/libs/*-SNAPSHOT.jar deploy/application.jar
         cp -r .ebextensions deploy/
         cp Procfile deploy/
         cd deploy && zip -r ../deploy.zip .


### PR DESCRIPTION
- build/libs/*.jar 패턴이 plain JAR도 포함하여 오류 발생
- *-SNAPSHOT.jar 패턴으로 변경하여 실행 가능한 JAR만 복사