### PR TITLE
fix: OAuth2 설정을 조건부로 변경

### DIFF
--- a/src/main/java/com/heybit/backend/security/config/OAuth2SecurityConfig.java
+++ b/src/main/java/com/heybit/backend/security/config/OAuth2SecurityConfig.java
@@ -4,11 +4,13 @@ import com.heybit.backend.security.oauth.CustomOAuth2UserService;
 import com.heybit.backend.security.oauth.OAuth2LoginFailureHandler;
 import com.heybit.backend.security.oauth.OAuth2LoginSuccessHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 
 @Configuration
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "spring.security.oauth2.client.registration.google.client-id")
 public class OAuth2SecurityConfig {
 
   private final CustomOAuth2UserService customOAuth2UserService;

--- a/src/main/java/com/heybit/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/heybit/backend/security/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.heybit.backend.security.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -15,7 +16,9 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
   private final JwtSecurityConfig jwtSecurityConfig;
-  private final OAuth2SecurityConfig oAuth2SecurityConfig;
+  
+  @Autowired(required = false)
+  private OAuth2SecurityConfig oAuth2SecurityConfig;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -36,8 +39,10 @@ public class SecurityConfig {
     // JWT 필터 설정 위임
     jwtSecurityConfig.configure(http);
 
-    // OAuth2 로그인 설정 위임
-    oAuth2SecurityConfig.configure(http);
+    // OAuth2 로그인 설정 위임 (OAuth2 설정이 있을 때만)
+    if (oAuth2SecurityConfig != null) {
+      oAuth2SecurityConfig.configure(http);
+    }
 
     return http.build();
   }


### PR DESCRIPTION
- OAuth2SecurityConfig에 @ConditionalOnProperty 추가
- SecurityConfig에서 OAuth2SecurityConfig를 선택적으로 사용
- OAuth2 클라이언트 설정이 없어도 애플리케이션 시작 가능
- Google OAuth 클라이언트 ID가 설정된 경우에만 OAuth2 활성화