### PR TITLE
Feature/swagger init

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.3'
+    id 'org.springframework.boot' version '3.4.1'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.1'
+    id 'org.springframework.boot' version '3.4.8'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/src/main/java/com/heybit/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/heybit/backend/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.heybit.backend.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("Heybit API 명세서")
+            .description("Heybit 서비스용 Swagger 명세입니다.")
+            .version("v1.0.0")
+        );
+  }
+}

--- a/src/main/java/com/heybit/backend/config/SwaggerConfig.java
+++ b/src/main/java/com/heybit/backend/config/SwaggerConfig.java
@@ -2,11 +2,15 @@ package com.heybit.backend.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+
+  private static final String SECURITY_SCHEME_NAME = "BearerAuth";
 
   @Bean
   public OpenAPI openAPI() {
@@ -15,6 +19,17 @@ public class SwaggerConfig {
             .title("Heybit API 명세서")
             .description("Heybit 서비스용 Swagger 명세입니다.")
             .version("v1.0.0")
+        )
+        .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+        .components(new io.swagger.v3.oas.models.Components()
+            .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                new SecurityScheme()
+                    .name("Authorization")
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")
+                    .in(SecurityScheme.In.HEADER)
+            )
         );
   }
 }

--- a/src/main/java/com/heybit/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/heybit/backend/security/config/SecurityConfig.java
@@ -29,7 +29,16 @@ public class SecurityConfig {
         .sessionManagement(session -> session.sessionCreationPolicy(
             SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/", "/login/**", "/oauth2/**", "/h2-console/**","/test/**").permitAll()
+            .requestMatchers(
+                "/",
+                "/login/**",
+                "/oauth2/**",
+                "/h2-console/**",
+                "/test/**",
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/swagger-ui.html"
+            ).permitAll()
             .anyRequest().authenticated()
         )
         .headers(headers -> headers

--- a/src/main/java/com/heybit/backend/security/oauth/LoginUser.java
+++ b/src/main/java/com/heybit/backend/security/oauth/LoginUser.java
@@ -1,5 +1,6 @@
 package com.heybit.backend.security.oauth;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,6 +10,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Parameter(hidden = true)
 public @interface LoginUser {
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,4 +46,10 @@ spring:
           jobStore:
             misfireThreshold: 60000
 
-
+springdoc:
+  api-docs:
+    enabled: true       # OpenAPI 문서 활성화
+  swagger-ui:
+    enabled: true       #Swagger UI 사용 여부
+    path: /swagger-ui.html  # Swagger 접속 경로 지정
+  override-with-generic-response: false  # 자동 응답 포맷 생성 비활성화


### PR DESCRIPTION
### Change
- springdoc-openapi 의존성 추가 및 Spring Boot 버전 관리
  - springdoc-openapi와의 호환성 문제 해결을 위해 Spring Boot 버전을 3.4.1로 임시 다운그레이드 후, 같은 버전대의 최신 안정화 버전인 3.4.8로 다시 업그레이드

- SwaggerConfig 클래스 생성 및 OpenAPI 메타 정보 설정
  - Swagger UI 상단 Authorize 버튼을 통한 JWT 토큰 입력 기능 활성화 
- Spring Security 설정에 Swagger 관련 URL 경로 permitAll 처리
- `@LoginUser` 커스텀 어노테이션이 붙은 파라미터 Swagger 문서 숨김 처리


### Test
- `http://localhost:8080/swagger-ui/index.htm` 페이지 정상 동작 확인


### TODO
- 추후 @Operation, @Tag 등 Swagger 어노테이션으로 API 설명과 상세히 추가할 예정