### PR TITLE
feat: OAuth 환경 변수 설정 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+KAKAO_CLIENT_ID=kakao_client_id
+KAKAO_CLIENT_SECRET=kakao_client_secret
+GOOGLE_CLIENT_SECRET=google_client_secret
+GOOGLE_CLIENT_ID=google_client_id

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ out/
 .vscode/
 
 # .yml file
+
+# Environment files
+.env
+.env.local
+*.env

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 
     implementation 'com.h2database:h2'
     runtimeOnly  'mysql:mysql-connector-java:8.0.33'
+    
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,3 +13,6 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  
+  config:
+    import: optional:file:.env.local[.properties]


### PR DESCRIPTION
## Summary
- OAuth 환경 변수 설정을 위한 `.env.local` 및 `.env.example` 파일 추가
- `spring-dotenv` 라이브러리 추가로 local 프로필에서 `.env.local` 파일 읽기 지원
- `.gitignore`에 환경 변수 파일 추가

## Changes
- `.env.example` 파일 생성 (템플릿)
- `.gitignore`에 환경 변수 파일 제외 설정 추가
- `build.gradle`에 `spring-dotenv:4.0.0` 의존성 추가
- `application-local.yml`에 `.env.local` import 설정 추가