### PR TITLE
feat: 사용자 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/heybit/backend/application/service/UserService.java
+++ b/src/main/java/com/heybit/backend/application/service/UserService.java
@@ -4,6 +4,7 @@ import com.heybit.backend.domain.user.User;
 import com.heybit.backend.domain.user.UserRepository;
 import com.heybit.backend.global.exception.ApiException;
 import com.heybit.backend.global.exception.ErrorCode;
+import com.heybit.backend.presentation.user.dto.UserProfileResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -38,5 +39,17 @@ public class UserService {
           log.error("USER_NOT_FOUND: userId={}", userId);
           return new ApiException(ErrorCode.USER_NOT_FOUND);
         });
+  }
+
+  @Transactional(readOnly = true)
+  public UserProfileResponse getUserProfile(Long userId) {
+    User user = getById(userId);
+    return UserProfileResponse.builder()
+        .id(user.getId())
+        .email(user.getEmail())
+        .nickname(user.getNickname())
+        .role(user.getRole())
+        .status(user.getStatus())
+        .build();
   }
 }

--- a/src/main/java/com/heybit/backend/presentation/user/UserController.java
+++ b/src/main/java/com/heybit/backend/presentation/user/UserController.java
@@ -3,6 +3,7 @@ package com.heybit.backend.presentation.user;
 import com.heybit.backend.application.service.UserService;
 import com.heybit.backend.global.response.ApiResponseEntity;
 import com.heybit.backend.presentation.user.dto.UpdateNicknameRequest;
+import com.heybit.backend.presentation.user.dto.UserProfileResponse;
 import com.heybit.backend.security.oauth.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
   private final UserService userService;
+
+  @GetMapping("/me")
+  public ApiResponseEntity<UserProfileResponse> getCurrentUserProfile(@LoginUser Long userId) {
+    UserProfileResponse profile = userService.getUserProfile(userId);
+    return ApiResponseEntity.success(profile);
+  }
 
   @GetMapping("/check-nickname")
   public ApiResponseEntity<Boolean> checkNicknameDuplicate(@RequestParam String nickname) {

--- a/src/main/java/com/heybit/backend/presentation/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/heybit/backend/presentation/user/dto/UserProfileResponse.java
@@ -1,0 +1,22 @@
+package com.heybit.backend.presentation.user.dto;
+
+import com.heybit.backend.domain.user.Role;
+import com.heybit.backend.domain.user.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserProfileResponse {
+
+  private Long id;
+  private String email;
+  private String nickname;
+  private Role role;
+  private UserStatus status;
+
+}


### PR DESCRIPTION
## Summary
- GET /api/v1/users/me 엔드포인트 추가
- 로그인된 사용자의 프로필 정보(닉네임, 이메일, 역할, 상태) 조회 기능 구현
- JWT 토큰 기반 인증을 통한 사용자 식별

## Changes
- UserProfileResponse DTO 생성
- UserService에 getUserProfile 메서드 추가
- UserController에 /me 엔드포인트 추가