### PR TITLE
feat: OAuth 로그인 후 요청 origin으로 동적 리다이렉트 지원

### DIFF
--- a/src/main/java/com/heybit/backend/security/config/OAuth2SecurityConfig.java
+++ b/src/main/java/com/heybit/backend/security/config/OAuth2SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.heybit.backend.security.config;
 
+import com.heybit.backend.security.oauth.CustomAuthorizationRequestResolver;
 import com.heybit.backend.security.oauth.CustomOAuth2UserService;
 import com.heybit.backend.security.oauth.OAuth2LoginFailureHandler;
 import com.heybit.backend.security.oauth.OAuth2LoginSuccessHandler;
@@ -16,9 +17,13 @@ public class OAuth2SecurityConfig {
   private final CustomOAuth2UserService customOAuth2UserService;
   private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
   private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+  private final CustomAuthorizationRequestResolver customAuthorizationRequestResolver;
 
   public void configure(HttpSecurity http) throws Exception {
     http.oauth2Login(oauth2 -> oauth2
+        .authorizationEndpoint(authorization -> authorization
+            .authorizationRequestResolver(customAuthorizationRequestResolver)
+        )
         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
         .successHandler(oAuth2LoginSuccessHandler)
         .failureHandler(oAuth2LoginFailureHandler)

--- a/src/main/java/com/heybit/backend/security/oauth/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/heybit/backend/security/oauth/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,103 @@
+package com.heybit.backend.security.oauth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+  private final ClientRegistrationRepository clientRegistrationRepository;
+  private final DefaultOAuth2AuthorizationRequestResolver defaultResolver;
+  
+  @Value("${app.cors.allowed-origins}")
+  private String allowedOrigins;
+
+  public CustomAuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+    this.clientRegistrationRepository = clientRegistrationRepository;
+    this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
+        clientRegistrationRepository, "/oauth2/authorization");
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+    OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request);
+    return processAuthorizationRequest(request, authorizationRequest);
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+    OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request, clientRegistrationId);
+    return processAuthorizationRequest(request, authorizationRequest);
+  }
+
+  private OAuth2AuthorizationRequest processAuthorizationRequest(
+      HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {
+    
+    if (authorizationRequest == null) {
+      return null;
+    }
+
+    String referer = request.getHeader("Referer");
+    String origin = extractOrigin(referer);
+    
+    if (origin != null && isAllowedOrigin(origin)) {
+      Map<String, Object> additionalParameters = new HashMap<>(authorizationRequest.getAdditionalParameters());
+      String stateData = encodeStateData(authorizationRequest.getState(), origin);
+      
+      return OAuth2AuthorizationRequest.from(authorizationRequest)
+          .state(stateData)
+          .additionalParameters(additionalParameters)
+          .build();
+    }
+    
+    return authorizationRequest;
+  }
+
+  private String extractOrigin(String referer) {
+    if (referer == null || referer.isEmpty()) {
+      return null;
+    }
+    
+    try {
+      URI uri = URI.create(referer);
+      String port = uri.getPort() > 0 ? ":" + uri.getPort() : "";
+      return uri.getScheme() + "://" + uri.getHost() + port;
+    } catch (Exception e) {
+      log.warn("Failed to extract origin from referer: {}", referer, e);
+      return null;
+    }
+  }
+
+  private boolean isAllowedOrigin(String origin) {
+    if (allowedOrigins == null || origin == null) {
+      return false;
+    }
+    
+    Set<String> allowedSet = Set.of(allowedOrigins.split(","));
+    boolean isAllowed = allowedSet.stream()
+        .map(String::trim)
+        .anyMatch(allowed -> allowed.equals(origin));
+    
+    log.info("Origin validation: {} is allowed: {}", origin, isAllowed);
+    return isAllowed;
+  }
+
+  private String encodeStateData(String originalState, String origin) {
+    String combinedData = originalState + "|" + origin;
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(combinedData.getBytes());
+  }
+}


### PR DESCRIPTION
## Summary
- OAuth 로그인 요청 origin에 따른 동적 리다이렉트 구현
- localhost:3000에서 로그인 시 localhost:3000으로 리다이렉트
- myheybit.com에서 로그인 시 myheybit.com으로 리다이렉트

## Changes
- CustomAuthorizationRequestResolver 추가 - OAuth state에 origin 정보 인코딩
- OAuth2LoginSuccessHandler 수정 - state에서 origin 추출 및 동적 리다이렉트
- OAuth2SecurityConfig 수정 - custom resolver 적용