### PR TITLE
feat: 타이머 포기에 대한 결과를 등록하는 기능

### DIFF
--- a/src/main/java/com/heybit/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/heybit/backend/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
   TIMER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 타이머를 찾을 수 없습니다."),
   NOT_OWNER_OF_TIMER(HttpStatus.FORBIDDEN, "타이머에 대한 권한이 없습니다."),
   INVALID_TIMER_TIME(HttpStatus.BAD_REQUEST, "타이머의 시작/종료 시간이 올바르지 않습니다."),
+  INVALID_TIMER_STATE(HttpStatus.BAD_REQUEST, "진행중인 타이머는 결과를 등록할 수 없습니다."),
 
   //TimerResult
   ALREADY_REGISTERED_RESULT(HttpStatus.BAD_REQUEST, "타이머 결과가 이미 등록되어 있습니다."),

--- a/src/main/java/com/heybit/backend/presentation/timerresult/TimerResultController.java
+++ b/src/main/java/com/heybit/backend/presentation/timerresult/TimerResultController.java
@@ -26,6 +26,12 @@ public class TimerResultController {
     return ApiResponseEntity.success(resultId);
   }
 
+  @PostMapping("/api/v1/timer-abandon")
+  public ApiResponseEntity<Long> registerTimerAbandon(@RequestBody TimerResultRequest request) {
+    Long resultId = timerResultService.abandonTimerResult(request);
+    return ApiResponseEntity.success(resultId);
+  }
+
   @GetMapping("/api/v1/timers/history")
   public ApiResponseEntity<List<CompletedTimerResponse>> getCompletedResultsByUserId(@LoginUser Long userId) {
     List<CompletedTimerResponse> responses = timerResultService.getCompletedResultsByUserId(userId);


### PR DESCRIPTION

### Change
- TimerResultService에 `abandonTimerResult()` 기능 추가
  - 타이머를 포기할 때 TimerResult를 저장
  - 해당 타이머에 등록된 알림 스케줄러 취소
  - 타이머 상태를 ABANDONED로 변경
  
### Test
-  abandonTimerResult() 에 대한 테스트 검증 완료